### PR TITLE
Add capability to track particles on rotated DISV MF6 grid.

### DIFF
--- a/source/MPath7.f90
+++ b/source/MPath7.f90
@@ -1,4 +1,4 @@
-!  MPath7.f90 
+!  MPath7.f90
 !  PROGRAM: MPath7
 
     program MPath7
@@ -21,13 +21,11 @@
     use ModpathSimulationDataModule,only : ModpathSimulationDataType
     use BudgetReaderModule,only : BudgetReaderType
     use HeadReaderModule,only : HeadReaderType
-    
     use ModflowRectangularGridModule,only : ModflowRectangularGridType
     use RectangularGridDisModule,only : RectangularGridDisType
     use RectangularGridDisMf6Module,only : RectangularGridDisMf6Type
     use RectangularGridDisvMf6Module,only : RectangularGridDisvMf6Type
-    use RectangularGridDisuMfusgModule,only : RectangularGridDisuMfusgType    
-    
+    use RectangularGridDisuMfusgModule,only : RectangularGridDisuMfusgType
     use TimeDiscretizationDataModule,only : TimeDiscretizationDataType
     use ParticleTrackingEngineModule,only : ParticleTrackingEngineType
     use TrackPathResultModule,only : TrackPathResultType
@@ -40,17 +38,15 @@
     use GeoReferenceModule,only : GeoReferenceType
     use CompilerVersion,only : get_compiler
     implicit none
-    
+
     ! Variables declarations
     type(HeadReaderType),allocatable :: headReader
     type(BudgetReaderType), allocatable :: budgetReader
-    
     class(ModflowRectangularGridType), pointer :: modelGrid
     class(RectangularGridDisType), allocatable, target :: disGrid
     class(RectangularGridDisMf6Type), allocatable, target :: disMf6Grid
     class(RectangularGridDisvMf6Type), allocatable, target :: disvMf6Grid
     class(RectangularGridDisuMfusgType), allocatable, target :: disuMfusgGrid
-
     type(TimeDiscretizationDataType), allocatable :: tdisData
     type(ParticleTrackingEngineType), allocatable,target :: trackingEngine
     type(ModpathBasicDataType), allocatable, target :: basicData
@@ -86,20 +82,17 @@
     character(len=10) version
     character(len=75) terminationMessage
     character(len=80) compilerVersionText
-    
 !---------------------------------------------------------------------------------
-    
     ! Set version
     version = '7.2.001'
-    
     call get_compiler(compilerVersionText)
     write(*,'(1x/a,a)') 'MODPATH Version ', version
     write(*,'(a)') compilerVersionText
     write(*,*)
-    
+
     ! Set the default termination message
     terminationMessage = "Normal termination."
-    
+
     ! Assign dedicated file unit numbers
      disUnit = 101
      endpointUnit = 102
@@ -118,7 +111,7 @@
      traceModeUnit = 115
      binPathlineUnit = 116
      gridMetaUnit = 117
-     
+
     ! Parse the command line for simulation file name, log file name, and options
     call ParseCommandLine(mpsimFile, mplogFile, logType)
     ! Open the log file (unless -nolog option)
@@ -133,8 +126,8 @@
         call ulog('Prompt for the name of the MODPATH simulation file.', logUnit)
         call PromptSimulationFile(mpsimFile)
     end if
-    
-    ! Read the first two records of the simulation file to get the names of the 
+
+    ! Read the first two records of the simulation file to get the names of the
     ! name file (mpnamFile) and the listing file (mplistFile)
     allocate(simulationData)
     open(unit=mpsimUnit, file=mpsimFile, status='old', form='formatted', access='sequential')
@@ -142,44 +135,42 @@
     call simulationData%ReadFileHeaders(mpsimUnit)
     mpnamFile = simulationData%NameFile
     mplistFile = simulationData%ListingFile
-    
+
     ! Open the MODPATH output listing file
     open(unit=mplistUnit, file=mplistFile, status='replace', form='formatted', access='sequential')
-    
     write(mplistUnit,'(1x/a,a)') 'MODPATH Version ', version
     write(mplistUnit,'(a)') compilerVersionText
     write(mplistUnit, *)
     write(mplistUnit, '(a)') 'This software has been approved for release by the U.S. Geological'
-    write(mplistUnit, '(a)') 'Survey (USGS). Although the software has been subjected to rigorous'    
-    write(mplistUnit, '(a)') 'review, the USGS reserves the right to update the software as needed'    
-    write(mplistUnit, '(a)') 'pursuant to further analysis and review. No warranty, expressed or'    
-    write(mplistUnit, '(a)') 'implied, is made by the USGS or the U.S. Government as to the'    
-    write(mplistUnit, '(a)') 'functionality of the software and related material nor shall the'    
-    write(mplistUnit, '(a)') 'fact of release constitute any such warranty. Furthermore, the'    
-    write(mplistUnit, '(a)') 'software is released on condition that neither the USGS nor the U.S.'    
-    write(mplistUnit, '(a)') 'Government shall be held liable for any damages resulting from its'    
-    write(mplistUnit, '(a)') 'authorized or unauthorized use. Also refer to the USGS Water'    
-    write(mplistUnit, '(a)') 'Resources Software User Rights Notice for complete use, copyright,'    
-    write(mplistUnit, '(a)') 'and distribution information.'    
+    write(mplistUnit, '(a)') 'Survey (USGS). Although the software has been subjected to rigorous'
+    write(mplistUnit, '(a)') 'review, the USGS reserves the right to update the software as needed'
+    write(mplistUnit, '(a)') 'pursuant to further analysis and review. No warranty, expressed or'
+    write(mplistUnit, '(a)') 'implied, is made by the USGS or the U.S. Government as to the'
+    write(mplistUnit, '(a)') 'functionality of the software and related material nor shall the'
+    write(mplistUnit, '(a)') 'fact of release constitute any such warranty. Furthermore, the'
+    write(mplistUnit, '(a)') 'software is released on condition that neither the USGS nor the U.S.'
+    write(mplistUnit, '(a)') 'Government shall be held liable for any damages resulting from its'
+    write(mplistUnit, '(a)') 'authorized or unauthorized use. Also refer to the USGS Water'
+    write(mplistUnit, '(a)') 'Resources Software User Rights Notice for complete use, copyright,'
+    write(mplistUnit, '(a)') 'and distribution information.'
     write(mplistUnit, *)
-    
-    
+
     ! Read the MODPATH name file
     call ReadNameFile(mpnamFile, mplistUnit, gridFileType)
-    
+
     ! Process spatial and time discretization data
     call ulog('Allocate rectangular unstructured grid component.', logUnit)
     allocate(modelGrid)
     call ulog('Allocate time discretization data component ...', logUnit)
     allocate(tdisData)
-    
+
     write(mplistUnit, '(1x/a)') 'Grid data'
     write(mplistUnit, '(a)')    '---------'
-      
+
     select case (gridFileType)
-        case (1) 
+        case (1)
             ! MODFLOW-2005 discretization file (DIS)
-            ! Read spatial and time discretization. 
+            ! Read spatial and time discretization.
             write(mplistUnit, '(a,1x)') 'Grid file type: MODFLOW-2005 discretization file (DIS)'
             call ulog('Allocate disGrid.', logUnit)
             allocate(disGrid)
@@ -187,12 +178,12 @@
             call disGrid%ReadData(disUnit, gridMetaUnit, mplistUnit, stressPeriodCount)
             modelGrid => disGrid
             call tdisData%ReadData(disUnit, mplistUnit, stressPeriodCount)
-            
+
             ! Close discretization files
             close(disUnit)
-            
+
         case (2)
-            ! MODPATH spatial(MPUGRID) and time (TDIS) discretization files 
+            ! MODPATH spatial(MPUGRID) and time (TDIS) discretization files
             ! Read spatial discretization
             write(mplistUnit, '(a,1x)') 'Grid file type: MODFLOW-USG unstructured grid file (DISU).'
             call ulog('Allocate disuMfusgGrid.', logUnit)
@@ -203,7 +194,7 @@
             call tdisData%ReadData(disUnit, mplistUnit, stressPeriodCount)
             ! Close discretization file
             close(disUnit)
-        
+
         case (3)
             ! MODFLOW-6 DIS binary grid file
             ! Read spatial discretization
@@ -213,7 +204,7 @@
             call ulog('Read DIS binary grid file.', logUnit)
             call disMf6Grid%ReadData(disUnit, gridMetaUnit, mplistUnit)
             modelGrid => disMf6Grid
-            
+
             ! Read time discretization file
             if(len_trim(tdisFile) .gt. 0) then
                 write(mplistUnit, '(a,1x)') 'Time discretization file type: MODFLOW-6 time discretization file.'
@@ -223,11 +214,11 @@
                 call ulog('The time discretization file was not specified.', logUnit)
                 call ustop('The time discretization file was not specified.')
             end if
-            
+
             ! Close discretization files
             close(disUnit)
             close(tdisUnit)
-            
+
         case (4)
             ! MODFLOW-6 DISV binary grid file
             ! Read spatial discretization
@@ -237,7 +228,7 @@
             call ulog('Read DISV binary grid file.', logUnit)
             call disvMf6Grid%ReadData(disUnit, gridMetaUnit, mplistUnit)
             modelGrid => disvMf6Grid
-           
+
             ! Read time discretization file
             if(len_trim(tdisFile) .gt. 0) then
                 write(mplistUnit, '(a,1x)') 'Time discretization file type: MODFLOW-6 time discretization file.'
@@ -247,21 +238,21 @@
                 call ulog('The time discretization file was not specified.', logUnit)
                 call ustop('The time discretization file was not specified.')
             end if
-            
+
             ! Close discretization files
             close(disUnit)
             close(tdisUnit)
-            
+
         case (5)
             ! MODFLOW-6 DISU binary grid file
-            write(mplistUnit, '(1x,a)') 'MODFLOW-6 DISU binary grid files are not yet supported. Stop.' 
-            
+            write(mplistUnit, '(1x,a)') 'MODFLOW-6 DISU binary grid files are not yet supported. Stop.'
+
         case default
             write(mplistUnit, '(1x,a)') 'Unknown grid file type. Stop.'
             stop
-            
+
         end select
-    
+
     ! Write connection data
     if (logType == 2) then
         call ulog('Skip output of cell connection data.', logUnit)
@@ -282,13 +273,13 @@
             write(logUnit, '(1x,25i8)') (buffer(m), m = 1, cellConnectionCount)
             call modelGrid%GetCellConnectionFaces(n, buffer, bufferSize, cellConnectionCount)
             write(logUnit, '(1x,25i8)') (buffer(m), m = 1, cellConnectionCount)
-            write(logUnit, *)        
+            write(logUnit, *)
         end do
     end if
-    
+
     ! Initialize the georeference data
     call geoRef%SetData(modelGrid%OriginX, modelGrid%OriginY, modelGrid%RotationAngle)
-    
+
     ! Initialize the budgetReader component
     call ulog('Allocate budget reader component.', logUnit)
     allocate(budgetReader)
@@ -300,34 +291,34 @@
     else
         call ustop('An error occurred processing the budget file. Stopping.')
     end if
-    
+
     ! Initialize the headReader component
     call ulog('Allocate head reader component.', logUnit)
     allocate(headReader)
     call ulog('Open head file in head reader component.', logUnit)
     call headReader%OpenFile(headFile, headUnit, mplistUnit)
-    
+
     ! Read the MODPATH basic data file
     call ulog('Allocate MODPATH basic data component.', logUnit)
     allocate(basicData)
-    call ulog('Read MODPATH basic data component.', logUnit)   
+    call ulog('Read MODPATH basic data component.', logUnit)
     call basicData%ReadData(mpbasUnit, mplistUnit, modelGrid)
-    
+
     ! Read the remainder of the MODPATH simulation file
     call ulog('Read the remainder of the MODPATH simulation data component.', logUnit)
     call simulationData%ReadData(mpsimUnit, mplistUnit, basicData%IBound, tdisData, modelGrid)
-        
+
     ! Budget File Data Summary
     ! If budget output option = 2, then write a list of budget record headers.
-    call WriteBudgetFileInfo(mplistUnit, budgetReader) 
+    call WriteBudgetFileInfo(mplistUnit, budgetReader)
     if(simulationData%BudgetOutputOption .eq. 2) call WriteBudgetRecordHeaders(mplistUnit, budgetReader)
-        
+
     ! Prepare to stop if there are no particles to track
     if(simulationData%TotalParticleCount .eq. 0) then
         terminationMessage = 'The simulation was terminated because there are no particles to track.'
         goto 100
     end if
-    
+
     ! Initialize the particle tracking engine:
     call ulog('Allocate particle tracking engine component.', logUnit)
     allocate(trackingEngine)
@@ -340,7 +331,7 @@
     call trackingEngine%SetDefaultIface(basicData%DefaultIfaceLabels,           &
       basicData%DefaultIfaceValues, basicData%DefaultIfaceCount)
     ! The trackingEngine initialization is complete
-    
+
     ! Compute range of time steps to use in the time step loop
     message ='Compute range of time steps. Prepare for time step loop'
     call ulog(message, logUnit)
@@ -352,8 +343,8 @@
     else
         klast = 1
         kincr = -1
-    end if 
-    
+    end if
+
     ! Set the appropriate value of stoptime. Start by setting stoptime to correspond to the start or the
     ! end of the simulation (depending on the tracking direction)
     if(simulationData%TrackingDirection .eq. 1) then
@@ -370,7 +361,7 @@
     !
     if(simulationData%StoppingTimeOption .eq. 2) then
         ! Set stoptime to 1.0d+30 if the EXTEND option is on and the boundary time step is steady state.
-        ! If the boundary time step is transient, leave stoptime set to correspond to the beginning or 
+        ! If the boundary time step is transient, leave stoptime set to correspond to the beginning or
         ! end of the simulation.
         if(trackingEngine%SteadyState) stoptime = 1.0d+30
     else if(simulationData%StoppingTimeOption .eq. 3) then
@@ -385,16 +376,16 @@
               stoptime = simulationData%StopTime
         end if
     end if
-    
+
     write(mplistUnit, '(1x/a,e15.7)')                                           &
       'The simulation will be run with stoptime = ', stoptime
 
     write(*,*)
-    write(*,'(A)') 'Run particle tracking simulation ...'    
+    write(*,'(A)') 'Run particle tracking simulation ...'
     write(mplistUnit, *)
     write(mplistUnit, *)
     write(mplistUnit,'(1X,A)') 'Run particle tracking simulation ...'
-    
+
     ! Allocate tPoint array
     tPointCount = 0
     if(simulationData%SimulationType .eq. 2) then
@@ -405,7 +396,7 @@
     end if
     if(allocated(tPoint)) deallocate(tPoint)
     allocate(tPoint(tPointCount))
-    
+
     ! Open particle output files
     open(unit=endpointUnit, file=simulationData%EndpointFile, status='replace', &
       form='formatted', access='sequential')
@@ -436,25 +427,25 @@
         write(traceModeUnit, '(1X,A,I10)')                                      &
           'Particle ID: ',simulationData%TraceID
     end if
-    
+
     ! Begin time step loop
     pathlineRecordCount = 0
     time = 0.0d0
     nt = 0
     if(allocated(cellData)) deallocate(cellData)
     allocate(cellData)
-    
+
     call ulog('Begin TIME_STEP_LOOP', logUnit)
     ! Call system_clock to get the start of the time step loop
     call system_clock(clockCountStart, clockCountRate, clockCountMax)
     TIME_STEP_LOOP: do ktime= kfirst,klast,kincr
-    
+
     ! Get the stress period and time step from the cummulative time step
     call tdisData%GetPeriodAndStep(ktime, period, step)
-    
+
     ! Load data for the current time step
     call trackingEngine%LoadTimeStep(period, step)
-    
+
     if(trackingEngine%SteadyState) then
       write(message,'(A,I5,A,I5,A,1PE12.5,A)') 'Processing Time Step ',step,        &
         ' Period ',period,'.  Time = ',tdisData%TotalTimes(ktime), &
@@ -473,14 +464,14 @@
     write(mplistUnit,'(1X,A,I6,A)') '  (Cumulative step = ', ktime,')'
     write(mplistUnit,'(1X,A)')                                                  &
       '----------------------------------------------------------------------------------------------'
-    
+
     ! Check water balance summary for the current time step
     if(simulationData%BudgetOutputOption .gt. 0)                                &
       call WriteWaterBalanceSummary(mplistUnit, trackingEngine, cellData)
-    
+
     ! Check cell-by-cell budgets for this time step
     if(simulationData%BudgetCellsCount .gt. 0) then
-        write(mplistUnit, *) 
+        write(mplistUnit, *)
         write(mplistUnit, '(1X,A,I10,A)') 'Cell data will be printed for',      &
           simulationData%BudgetCellsCount, ' cells.'
         do n = 1, simulationData%BudgetCellsCount
@@ -490,9 +481,9 @@
               simulationData%TrackingOptions%BackwardTracking)
         end do
     end if
-    
-    ! Compute the tracking time corresponding to the end or beginning 
-    ! of this MODFLOW time step (depending on whether this is a forward 
+
+    ! Compute the tracking time corresponding to the end or beginning
+    ! of this MODFLOW time step (depending on whether this is a forward
     ! or backward tracking run.)
     message = 'Compute TSMAX'
     call ulog(message, logUnit)
@@ -505,8 +496,8 @@
           if(ktime .eq. tdisData%CumulativeTimeStepCount) then
               tsMax = stoptime
           else
-              if(tsMax .gt. stoptime) tsMax = stoptime    
-          end if 
+              if(tsMax .gt. stoptime) tsMax = stoptime
+          end if
       end if
     else
       ! Backward tracking
@@ -521,11 +512,11 @@
           if(ktime .eq. 1) then
               tsMax = stoptime
           else
-              if(tsMax .gt. stoptime) tsMax = stoptime    
-          end if 
+              if(tsMax .gt. stoptime) tsMax = stoptime
+          end if
       end if
     end if
-    
+
     ! If simulation type is TIMESERIES, write initial locations of all particles active at tracking time = 0
     if((simulationData%SimulationType .ge.3) .and. (ktime .eq. kfirst)) then
         do groupIndex =1, simulationData%ParticleGroupCount
@@ -545,27 +536,27 @@
                       p%InitialGlobalZ = pCoord%GlobalZ
                       p%GlobalZ = p%InitialGlobalZ
                       call WriteTimeseriesRecord(p%SequenceNumber, p%ID,        &
-                        groupIndex, ktime, 0, pCoord, geoRef, timeseriesUnit)
+                        groupIndex, ktime, 0, pCoord, geoRef, timeseriesUnit, modelGrid)
                   end if
             end do
         end do
     end if
-    
-    
 
-    ! TRACKING_INTERVAL_LOOP: 
+
+
+    ! TRACKING_INTERVAL_LOOP:
     ! Loop through all the required time points that fall within the
-    ! current MODFLOW time step. For runs that do not have any specified 
-    ! time points, there will only be one time point that corresponds either 
-    ! to the beginning or end of the current MODFLOW time step or to the 
+    ! current MODFLOW time step. For runs that do not have any specified
+    ! time points, there will only be one time point that corresponds either
+    ! to the beginning or end of the current MODFLOW time step or to the
     ! specified stop time for the MODPATH analysis.
     itend = 0
     call ulog('Begin TRACKING_INTERVAL_LOOP', logUnit)
     TRACKING_INTERVAL_LOOP: do while (itend .eq. 0)
-    
+
     itend = 1
     maxTime = tsMax
-    if(simulationData%SimulationType .gt. 1) then     
+    if(simulationData%SimulationType .gt. 1) then
         ! For timeseries and pathline runs, find out if maxTime should be set to the value of the
         ! next time point or the time at the end of the time step
         if (nt+1 .le. simulationData%TimePointCount) then
@@ -578,7 +569,7 @@
             end if
         end if
     end if
-    
+
     ! Track particles
     pendingCount = 0
     activeCount = 0
@@ -586,25 +577,25 @@
         do groupIndex = 1, simulationData%ParticleGroupCount
             do particleIndex = 1, simulationData%ParticleGroups(groupIndex)%TotalParticleCount
                 p => simulationData%ParticleGroups(groupIndex)%Particles(particleIndex)
-                ! Check particle status. 
-                ! Skip over particles unless they are active or pending release         
+                ! Check particle status.
+                ! Skip over particles unless they are active or pending release
                 if(p%Status .gt. 1) then
                     ! Add code here later to deal with advective observations
                     ! For now, just cycle to the next particle
                     cycle
                 end if
-                
+
                 ! Check to see if trace mode should be turned on for this particle
                 traceModeOn = .false.
-                if(simulationData%TraceMode .gt. 0) then 
+                if(simulationData%TraceMode .gt. 0) then
                     if((p%Group .eq. simulationData%TraceGroup) .and.           &
                       (p%ID .eq. simulationData%TraceID)) traceModeOn = .true.
                 end if
-                
+
                 ! If a particle is pending release (STATUS = 0), check to see if it should
                 ! be set to active and released on this pass. If the particle is pending
                 ! release and its release time is earlier than the starting time of this
-                ! pass, then mark the particle status as permanently unreleased 
+                ! pass, then mark the particle status as permanently unreleased
                 ! (STATUS = 8).
                 if(p%Status .eq. 0) then
                     if(p%InitialTrackingTime .lt. time) then
@@ -617,7 +608,7 @@
                                 p%Status = 7
                             end if
                         else
-                            ! Drape option is in effect. Find the top-most active cell starting with the initial cell number. 
+                            ! Drape option is in effect. Find the top-most active cell starting with the initial cell number.
                             ! If no active cell is found, leave the cell number set to its original value and set the Status = 7
                             ! to indicate it is stranded in an inactive cell.
                             topActiveCellNumber = trackingEngine%GetTopMostActiveCell(p%CellNumber)
@@ -632,12 +623,12 @@
                         p%GlobalZ = p%InitialGlobalZ
                     end if
                 end if
-         
+
                 ! Count the number of particles that are currently active or pending
-                ! release at the beginning of this pass.         
+                ! release at the beginning of this pass.
                 if(p%Status .EQ. 0) pendingCount = pendingCount + 1
                 if(p%Status .EQ. 1) activeCount = activeCount + 1
-                
+
                 ! Track the particle if it is active
                 if(p%Status .eq. 1) then
                     ! Set particle location buffer
@@ -647,12 +638,12 @@
                     pLoc%LocalY = p%LocalY
                     pLoc%LocalZ = p%LocalZ
                     pLoc%TrackingTime = p%TrackingTime
-                    
+
                     ! Call TrackPath
                     call trackingEngine%TrackPath(trackPathResult, traceModeOn, &
                       traceModeUnit, p%Group, p%ID, p%SequenceNumber, pLoc,     &
                       maxTime, tPoint, tPointCount)
-                    
+
                     ! Update endpoint data. The Face property will only be updated when the endpoint file is written
                     plCount = trackPathResult%ParticlePath%Pathline%GetItemCount()
                     tsCount = trackPathResult%ParticlePath%Timeseries%GetItemCount()
@@ -665,7 +656,7 @@
                     p%LocalZ = pCoordLast%LocalZ
                     p%GlobalZ = pCoordLast%GlobalZ
                     p%TrackingTime = pCoordLast%TrackingTime
-                    
+
                     ! Update particle status
                     status = trackPathResult%Status
                     if(  status .eq. trackPathResult%Status_ReachedBoundaryFace()) then
@@ -685,7 +676,6 @@
                     else
                         ! Leave status set to active (status = 1)
                     end if
-                    
                     ! Write particle output
                     if((simulationData%SimulationType .eq. 2) .or.              &
                       (simulationData%SimulationType .eq. 4)) then
@@ -696,31 +686,32 @@
                                 case (1)
                                     call WriteBinaryPathlineRecord(             &
                                       trackPathResult, binPathlineUnit, period, &
-                                      step, geoRef)
+                                      step, geoRef, modelGrid)
                                 case (2)
                                     call WritePathlineRecord(trackPathResult,   &
-                                      pathlineUnit, period, step, geoRef)
+                                      pathlineUnit, period, step, geoRef, modelGrid)
                             end select
-                            
+
                         end if
-                    end if              
+                    end if
                     if(simulationData%SimulationType .ge. 3) then
                         if(tsCount .gt. 0) then
                         ! Write timeseries record to the timeseries file
                             pCoordTP => trackPathResult%ParticlePath%Timeseries%Items(1)
                             call WriteTimeseriesRecord(p%SequenceNumber, p%ID,  &
-                              groupIndex, ktime, nt, pCoordTP, geoRef, timeseriesUnit)
+                              groupIndex, ktime, nt, pCoordTP, geoRef, timeseriesUnit, &
+							  modelGrid)
                         end if
                     end if
                 end if
-                
+
             end do
         end do
     end if
-    
+
     ! Update tracking time
     time = maxTime
-    
+
     ! Check to see if there are any particles remaining to track in the next
     ! pass. If not, exit the loop.
     if(simulationData%ParticleGroupCount .gt. 0) then
@@ -730,37 +721,37 @@
         end if
     end if
 
-    end do TRACKING_INTERVAL_LOOP   
+    end do TRACKING_INTERVAL_LOOP
     call ulog('Exit TRACKING_INTERVAL_LOOP', logUnit)
-       
+
     ! Exit TIME_STEP_LOOP if the tracking time has reached the specified stop time.
     IF(time .ge. stoptime) exit TIME_STEP_LOOP
 
     end do TIME_STEP_LOOP
     call ulog('Exit TIME_STEP_LOOP', logUnit)
-    
+
     ! Stop timer
     call system_clock(clockCountStop, clockCountRate, clockCountMax)
-    
+
     ! Write endpoint file
     if(simulationData%ParticleGroupCount .gt. 0) then
         call ulog('Write endpoint file.', logUnit)
-        call WriteEndpoints(simulationData, modelGrid, geoRef, endpointUnit)
+	call WriteEndpoints(simulationData, modelGrid, geoRef, endpointUnit)
     end if
-    
+
     ! Finalize and process binary pathline file if pathline format option = 1
     if((simulationData%SimulationType .eq. 2) .or. (simulationData%SimulationType .eq. 4)) then
         if(simulationData%PathlineFormatOption .eq. 1) then
             call ulog('Consolidating pathline segments.', logUnit)
             call ConsolidatePathlines(binPathlineUnit, pathlineUnit,            &
-              pathlineRecordCount, simulationData%TotalParticleCount) 
+              pathlineRecordCount, simulationData%TotalParticleCount)
         end if
     end if
-    
+
     ! Write particle summary information
     call WriteParticleSummaryInfo(simulationData, mplistUnit)
-    
-100 continue    
+
+100 continue
     ! Deallocate major components
     call ulog('Begin memory deallocation.', logUnit)
     if(allocated(headReader)) deallocate(headReader)
@@ -770,14 +761,14 @@
     if(allocated(basicData)) deallocate(basicData)
     if(allocated(simulationData)) deallocate(simulationData)
     call ulog('Memory deallocation complete.', logUnit)
-    
+
     write(*, '(a)') terminationMessage
     write(mplistUnit, '(1x/,a)', err=200) terminationMessage
     elapsedTime = dble(clockCountStop - clockCountStart) / dble(clockCountRate)
     write(mplistUnit, '(1X,A,E15.5,A)') 'Elapsed time = ', elapsedTime, ' seconds'
-    
+
     ! Close files
-200 continue    
+200 continue
     close(mplistUnit)
     if (logType /= 0) close(logUnit)
 
@@ -785,9 +776,9 @@
     ! The pause statement keeps the command window from immediately closing when the MODPATH run completes.
     ! For a compiled executable, do not use the pause statement, but run the executable from inside a batch
     ! file to keep the window from closing immediately.
-    
+
     !pause
-    
+
     contains
 
     subroutine ParseCommandLine(mpsimFile, mplogFile, logType)
@@ -805,10 +796,10 @@
     integer :: narg, length, status, ndot, nlast, na, nc
     logical :: exists
 !---------------------------------------------------------------------------------------------------------------
-    
+
     ! Get the number of command-line arguments
     narg = command_argument_count()
-    
+
     ! Initialize mpsimFile, mplogFile, and logType
     mpsimFile = ""
     mplogFile = ""
@@ -864,12 +855,12 @@
     end do
     if ((mplogFile /= "") .and. (logType.eq.0))                                   &
         call ustop('Options -logname and -nolog both on the command line. Stop.')
-    
+
     ! If log file name not specified, set to default
     if (mplogFile == "") mplogFile = "mpath7.log"
 
     return
-    
+
     end subroutine ParseCommandLine
 
     subroutine PromptSimulationFile(mpsimFile)
@@ -893,7 +884,7 @@
     read(*, '(a)') mpsimFile
     call urword(mpsimFile,icol,istart,istop,0,n,r,0,0)
     mpsimFile = mpsimFile(istart:istop)
-    
+
     ! Check for existence of simulation file, adding .mpsim extension if necessary
     call CheckSimulationFile(mpsimFile)
 
@@ -913,7 +904,7 @@
     integer :: nc
     logical :: exists
 !---------------------------------------------------------------------------------------------------------------
-    
+
     ! Check for existence of the file
     inquire (file=mpsimFile, exist=exists)
     if(.not. exists) then
@@ -926,9 +917,9 @@
     mpsimFile = trim(mpsimFile)
 
     return
-    
+
     end subroutine CheckSimulationFile
-    
+
     subroutine ReadNameFile(filename, outUnit, gridFileType)
 !***************************************************************************************************************
 ! Description goes here
@@ -952,9 +943,9 @@
     doubleprecision :: r
     logical :: complete
 !---------------------------------------------------------------------------------------------------------------
-    
+
     errMessage = ' '
-    
+
     do n = 1, 6
         nfiltyp(n) = 0
     end do
@@ -964,13 +955,13 @@
     headFile = ' '
     budgetFile = ' '
     gridMetaFile = ' '
-    
+
     inUnit = 99
     open(unit=inUnit, file=filename, status='old', form='formatted', access='sequential')
-    
+
     write(outUnit, '(1x/a)') 'MODPATH name file data'
     write(outUnit, '(a)')    '----------------------'
-    
+
         gridFileType = 0
     do
         read(inUnit, '(a)', end=1000) line
@@ -979,14 +970,14 @@
         if(line(1:1) .eq. '#') cycle
         if(line(1:1) .eq. '!') cycle
         if(line(1:2) .eq. '//') cycle
-        
+
         ! Check for unit numbers
         numflag = 0
         read(line, *, err=200) filtyp, n
         numflag = 1
         goto 200
 200     continue
-        
+
         icol=1
         call urword(line, icol, istart, istop, 1, n, r, outUnit, inUnit)
         filtyp = line(istart:istop)
@@ -996,7 +987,7 @@
         call urword(line, icol, istart, istop, 0, n, r, outUnit, inUnit)
         iflen = istop - istart + 1
         fname = line(istart:istop)
-        
+
         if(filtyp .eq. 'DIS') then
             gridFile = fname(1:iflen)
             open(unit=disUnit,file=gridFile,status='old', form='formatted', access='sequential')
@@ -1053,13 +1044,13 @@
             write(outUnit,'(A15,A)') 'GRIDMETA File: ', gridMetaFile(1:iflen)
             nfiltyp(6) = 1
         end if
-          
+
         cycle
-        
+
     end do
-    
+
 1000 continue
-     
+
      if(gridFileType .eq. 0) then
         message = 'No valid grid file type was specified in the name file. Stop.'
         call ustop(message)
@@ -1084,14 +1075,14 @@
              call ustop(message)
          end if
      end if
-    
+
 100 continue
     return
 500 continue
     call ustop(errMessage)
-    
+
     end subroutine
-    
+
     subroutine WriteBudgetFileInfo(outUnit, budgetReader)
 !***************************************************************************************************************
 ! Description goes here
@@ -1103,14 +1094,14 @@
     use BudgetRecordHeaderModule,only : BudgetRecordHeaderType
     integer,intent(in) :: outUnit
     type(BudgetReaderType),intent(in) :: budgetReader
-    
+
     write(outUnit,*)
     write(outUnit, '(1x,a)') 'Budget File Data'
     write(outUnit, '(1x,a)') '----------------'
     if(budgetReader%GetBudgetType() .eq. 1) then
         write(outUnit, '(1x,a20,2x,a)') 'Budget file type:',  'Structured grid'
     else if(budgetReader%GetBudgetType() .eq. 2) then
-        write(outUnit, '(1x,a20,2x,a)') 'Budget file type:',  'Unstructured grid' 
+        write(outUnit, '(1x,a20,2x,a)') 'Budget file type:',  'Unstructured grid'
     else
         write(outUnit, '(1x,a20,2x,a)') 'Budget file type:',  'Undetermined type'
         return
@@ -1118,18 +1109,18 @@
     if(budgetReader%GetBudgetFileFormat() .eq. 1) then
         write(outUnit, '(1x,a20,2x,a)') 'Budget file format:',  'Standard'
     else if(budgetReader%GetBudgetFileFormat() .eq. 2) then
-        write(outUnit, '(1x,a20,2x,a)') 'Budget file format:',  'Compact'           
+        write(outUnit, '(1x,a20,2x,a)') 'Budget file format:',  'Compact'
     end if
     if(budgetReader%GetPrecisionType() .eq. 1) then
             write(outUnit, '(1x,a20,2x,a)') 'Budget precision:',  'Single'
     else if(budgetReader%GetPrecisionType() .eq. 2) then
-            write(outUnit, '(1x,a20,2x,a)') 'Budget precision:',  'Double'            
+            write(outUnit, '(1x,a20,2x,a)') 'Budget precision:',  'Double'
     end if
-    
+
     return
-    
+
     end subroutine WriteBudgetFileInfo
-    
+
     subroutine WriteBudgetRecordHeaders(outUnit, budgetReader)
 !***************************************************************************************************************
 ! Description goes here
@@ -1143,7 +1134,7 @@
     type(BudgetReaderType),intent(in) :: budgetReader
     integer :: n, m, auxCount, recordHeaderCount
     type(BudgetRecordHeaderType) :: budgetRecordHeader
-    
+
     write(outUnit,*)
     write(outUnit, '(1x,a)') 'Budget Record Headers:'
     if(budgetReader%GetBudgetFileFormat() .eq. 1) then
@@ -1178,15 +1169,15 @@
                 end do
             else if(budgetRecordHeader%Method .eq. 2) then
                 write(outUnit, '(58x,a,i10)')                                   &
-                  'List item count = ', budgetRecordHeader%ListItemCount                    
+                  'List item count = ', budgetRecordHeader%ListItemCount
             end if
         end do
     end if
-    
+
     return
-        
+
     end subroutine WriteBudgetRecordHeaders
-    
+
     subroutine WriteWaterBalanceSummary(outUnit, trackingEngine, cellData)
 !***************************************************************************************************************
 ! Description goes here
@@ -1203,7 +1194,7 @@
     doubleprecision :: maxError
     doubleprecision,dimension(6) :: budgetIntervalBreaks
     integer,dimension(7) :: budgetIntervalBins
-    
+
         budgetIntervalBreakCount = 6
         budgetIntervalBreaks(1) = 1.0d-02
         budgetIntervalBreaks(2) = 1.0d-01
@@ -1215,16 +1206,16 @@
         maxError = 0.0d0
         do n = 1, budgetIntervalBreakCount  + 1
             budgetIntervalBins(n) = 0
-        end do 
-        
+        end do
+
         call trackingEngine%GetVolumetricBalanceSummary(                        &
           budgetIntervalBreakCount, budgetIntervalBreaks, budgetIntervalBins,   &
           maxError, maxErrorCell)
-        
+
         write(outUnit, *)
         write(outUnit, '(1X,A)') 'Volumetric water balance summary:'
         write(outUnit, *)
-        
+
         write(outUnit, '(1X,I10,A,F8.2,A)')                                     &
           budgetIntervalBins(1), ' cells had errors less than or equal to',     &
           budgetIntervalBreaks(1), ' percent'
@@ -1232,13 +1223,13 @@
             write(outUnit, '(1X,I10,A,F8.2,A,F8.2,A)')                          &
               budgetIntervalBins(n), ' cells had errors between ',              &
               budgetIntervalBreaks(n-1), ' and ',                               &
-              budgetIntervalBreaks(n), ' percent'                
+              budgetIntervalBreaks(n), ' percent'
         end do
         write(outUnit, '(1X,I10,A,F8.2,A)')                                     &
           budgetIntervalBins(budgetIntervalBreakCount + 1),                     &
           ' cells had errors greater than ',                                    &
           budgetIntervalBreaks(budgetIntervalBreakCount), ' percent'
-        
+
         write(outUnit, *)
         write(outUnit, '(1X,A,E12.5,A,I10)')                                    &
           'A maximum error of ', maxError, ' percent occurred in cell ',        &
@@ -1247,11 +1238,11 @@
         call trackingEngine%FillCellBuffer(maxErrorCell, cellData)
         call trackingEngine%WriteCellBuffer(outUnit, cellData,                  &
           simulationData%TrackingOptions%BackwardTracking)
-    
+
         return
-        
+
     end subroutine WriteWaterBalanceSummary
-    
+
     subroutine WriteParticleSummaryInfo(simulationData, outUnit)
 !***************************************************************************************************************
 ! Description goes here
@@ -1266,11 +1257,11 @@
     integer,intent(in) :: outUnit
     integer :: groupIndex, particleIndex, n
     integer,dimension(0:9) :: statusBins
-    
+
     do n = 0, 9
         statusBins(n) = 0
     end do
-    
+
     do groupIndex = 1, simulationData%ParticleGroupCount
         do particleIndex = 1, simulationData%ParticleGroups(groupIndex)%TotalParticleCount
             p => simulationData%ParticleGroups(groupIndex)%Particles(particleIndex)
@@ -1281,7 +1272,7 @@
             end if
         end do
     end do
-    
+
     ! Write to listing file
     write(outUnit, '(1x/a)') 'Particle Summary:'
     write(outUnit, '(i10,1x,a)') statusBins(0), 'particles are pending release.'
@@ -1291,7 +1282,7 @@
     write(outUnit, '(i10,1x,a)') statusBins(4), 'particles terminated at weak source cells.'
     write(outUnit, '(i10,1x,a)') statusBins(5),                                 &
       'particles terminated at strong source/sink cells or other cells with no potential exit face.'
-    write(outUnit, '(i10,1x,a)') statusBins(6), 'particles terminated in cells with a specified zone number.'    
+    write(outUnit, '(i10,1x,a)') statusBins(6), 'particles terminated in cells with a specified zone number.'
     write(outUnit, '(i10,1x,a)') statusBins(7), 'particles were stranded in inactive or dry cells.'
     write(outUnit, '(i10,1x,a)') statusBins(8), 'particles were unreleased.'
     write(outUnit, '(i10,1x,a)') statusBins(9), 'particles have an unknown status.'
@@ -1305,13 +1296,13 @@
     write(*, '(i10,1x,a)') statusBins(3), 'particles terminated at weak sink cells.'
     write(*, '(i10,1x,a)') statusBins(4), 'particles terminated at weak source cells.'
     write(*, '(i10,1x,a)') statusBins(5), 'particles terminated at strong source/sink cells.'
-    write(*, '(i10,1x,a)') statusBins(6), 'particles terminated in cells with a specified zone number.'    
+    write(*, '(i10,1x,a)') statusBins(6), 'particles terminated in cells with a specified zone number.'
     write(*, '(i10,1x,a)') statusBins(7), 'particles were stranded in inactive or dry cells.'
     write(*, '(i10,1x,a)') statusBins(8), 'particles were unreleased.'
     write(*, '(i10,1x,a)') statusBins(9), 'particles have an unknown status.'
     write(*, '(a)') ' '
-    
+
     end subroutine WriteParticleSummaryInfo
-        
+
     end program MPath7
 

--- a/source/ParticleManager.f90
+++ b/source/ParticleManager.f90
@@ -4,15 +4,18 @@ module ParticleManagerModule
   use ParticleCoordinateModule,only : ParticleCoordinateType
   use ModpathSimulationDataModule,only : ModpathSimulationDataType
   use GeoReferenceModule,only : GeoReferenceType
+  use UtilMiscModule,only : rotate_pivot
   implicit none
-  
+
   contains
 
-  
+
   subroutine WriteEndpoints(simData, grid, geoRef, outUnit)
   use ModflowRectangularGridModule,only : ModflowRectangularGridType
+  use RectangularGridDisvMf6Module,only : RectangularGridDisvMf6Type
   implicit none
   integer,intent(in) :: outUnit
+  doubleprecision :: xPivot, yPivot, rotAngle
   integer :: version, subversion, pgIndex, pIndex, n, face, zone, initialZone,  &
     totalCount, releaseCount, maximumID
   doubleprecision :: initialGlobalX, initialGlobalY, initialGlobalZ, globalX,   &
@@ -22,10 +25,20 @@ module ParticleManagerModule
   class(ModflowRectangularGridType),intent(in) :: grid
   type(ModpathSimulationDataType),intent(in),target :: simData
   type(GeoReferenceType),intent(in) :: geoRef
-  
+
   version = 7
   subversion = 2
-  
+  select type(grid)
+	class is (RectangularGridDisvMf6Type)
+		xPivot = grid%xPivot
+		yPivot = grid%yPivot
+		rotAngle = grid%rotAngle
+	class default
+		xPivot = 0.0d8
+	        yPivot = 0.0d8
+		rotAngle = 0.0d8
+  end select
+
   ! Compute status sums for all particles
   totalCount = 0
   releaseCount = 0
@@ -33,7 +46,7 @@ module ParticleManagerModule
   do n = 0, 9
       statusSums(n) = 0
   end do
-  
+
   do pgIndex = 1, simData%ParticleGroupCount
       do pIndex = 1, simData%ParticleGroups(pgIndex)%TotalParticleCount
           totalCount = totalCount + 1
@@ -45,7 +58,7 @@ module ParticleManagerModule
       end do
   end do
   releaseCount = totalCount - statusSums(0) - statusSums(8)
-  
+
   write(outUnit, '(a,2i10)') 'MODPATH_ENDPOINT_FILE', version, subversion
   write(outUnit, '(i5,3i10,1x,4e18.10)') simData%TrackingDirection, totalCount, releaseCount, maximumID, &
       simData%ReferenceTime, grid%OriginX, grid%OriginY, grid%RotationAngle
@@ -55,33 +68,43 @@ module ParticleManagerModule
       write(outUnit, '(a)') simData%ParticleGroups(n)%Name
   end do
   write(outUnit, '(a)') 'END HEADER'
-  
+
   do pgIndex = 1, simData%ParticleGroupCount
       do pIndex = 1, simData%ParticleGroups(pgIndex)%TotalParticleCount
-          p => simData%ParticleGroups(pgIndex)%Particles(pIndex)
-          if((p%Status .ne. 0) .and. (p%Status .ne. 8) ) then
-              call grid%ConvertToModelXYZ(p%InitialCellNumber,                 &
-                p%InitialLocalX, p%InitialLocalY, p%InitialLocalZ,              &
-                initialModelX, initialModelY, initialGlobalZ)
-              call grid%ConvertToModelXYZ(p%CellNumber, p%LocalX, p%LocalY,    &
-                p%LocalZ, modelX, modelY, globalZ)
-              face = FindFace(p%LocalX, p%LocalY, p%LocalZ)
-              initialZone = simData%Zones(p%InitialCellNumber)
-              zone = simData%Zones(p%CellNumber)
-              write(outUnit, '(3i10,i5,2es18.9e3,i10,i5,6es18.9e3,2i5,i10,i5,6es18.9e3,2i5)') &
-                p%SequenceNumber, p%Group, p%ID, p%Status,                      &
-                p%InitialTrackingtime, p%TrackingTime, p%InitialCellNumber,     &
-                p%InitialLayer, p%InitialLocalX, p%InitialLocalY,               &
-                p%InitialLocalZ, initialModelX, initialModelY,                &
-                initialGlobalZ, initialZone, p%InitialFace, p%CellNumber,     &
-                p%Layer, p%LocalX, p%LocalY, p%LocalZ, modelX, modelY,        &
-                globalZ, zone, face
+			p => simData%ParticleGroups(pgIndex)%Particles(pIndex)
+			if((p%Status .ne. 0) .and. (p%Status .ne. 8) ) then
+				call grid%ConvertToModelXYZ(p%InitialCellNumber,                 &
+					p%InitialLocalX, p%InitialLocalY, p%InitialLocalZ,           &
+					initialModelX, initialModelY, initialGlobalZ)
+
+				if (rotAngle .ne. 0.0d8) then
+					call rotate_pivot(xPivot, yPivot, rotAngle, initialModelX, initialModelY)
+				end if
+
+				call grid%ConvertToModelXYZ(p%CellNumber, p%LocalX, p%LocalY,    &
+						p%LocalZ, modelX, modelY, globalZ)
+
+				if (rotAngle .ne. 0.0d8) then
+					call rotate_pivot(xPivot, yPivot, rotAngle, modelX, modelY)
+				end if
+
+				face = FindFace(p%LocalX, p%LocalY, p%LocalZ)
+				initialZone = simData%Zones(p%InitialCellNumber)
+				zone = simData%Zones(p%CellNumber)
+				write(outUnit, '(3i10,i5,2es18.9e3,i10,i5,6es18.9e3,2i5,i10,i5,6es18.9e3,2i5)') &
+					p%SequenceNumber, p%Group, p%ID, p%Status,                      &
+					p%InitialTrackingtime, p%TrackingTime, p%InitialCellNumber,     &
+					p%InitialLayer, p%InitialLocalX, p%InitialLocalY,               &
+					p%InitialLocalZ, initialModelX, initialModelY,                &
+					initialGlobalZ, initialZone, p%InitialFace, p%CellNumber,     &
+					p%Layer, p%LocalX, p%LocalY, p%LocalZ, modelX, modelY,        &
+					globalZ, zone, face
           end if
       end do
   end do
-  
-  
+
   end subroutine WriteEndpoints
+
 
   subroutine WriteTimeseriesHeader(outUnit, trackingDirection, referenceTime,   &
       originX, originY, rotationAngle)
@@ -89,34 +112,56 @@ module ParticleManagerModule
   integer,intent(in) :: outUnit, trackingDirection
   doubleprecision,intent(in) :: referenceTime, originX, originY, rotationAngle
   integer :: version, subversion
-  
+
   version = 7
   subversion = 2
   write(outUnit, '(a,2i10)') 'MODPATH_TIMESERIES_FILE', version, subversion
-  write(outUnit, '(i5,1x,4e18.10)') trackingDirection, referenceTime, originX, originY, & 
+  write(outUnit, '(i5,1x,4e18.10)') trackingDirection, referenceTime, originX, originY, &
       rotationAngle
   write(outUnit, '(a)') 'END HEADER'
-  
+
   end subroutine WriteTimeseriesHeader
-  
+
+
   subroutine WriteTimeseriesRecord(sequenceNumber, particleID, groupIndex,      &
-    timeStep, timePointIndex, pCoord, geoRef, outUnit)
+    timeStep, timePointIndex, pCoord, geoRef, outUnit, grid)
+  use ModflowRectangularGridModule,only : ModflowRectangularGridType
+  use RectangularGridDisvMf6Module,only : RectangularGridDisvMf6Type
   implicit none
   type(ParticleCoordinateType),intent(in) :: pCoord
   type(GeoReferenceType),intent(in) :: geoRef
   integer,intent(in) :: outUnit, particleID, timePointIndex, groupIndex,        &
     timeStep, sequenceNumber
+  class(ModflowRectangularGridType),intent(in) :: grid 
+  
+  doubleprecision :: xPivot, yPivot, rotAngle	
   doubleprecision :: modelX, modelY, globalX, globalY
+  
+  select type(grid)
+	class is (RectangularGridDisvMf6Type)
+		xPivot = grid%xPivot
+		yPivot = grid%yPivot
+		rotAngle = grid%rotAngle
+	class default
+		xPivot = 0.0d8
+        yPivot = 0.0d8
+		rotAngle = 0.0d8
+  end select
   
   modelX = pCoord%GlobalX
   modelY = pCoord%GlobalY
-  
+  ! un-rotate only if necessary
+  if (rotAngle .ne. 0.0d0) then
+	call rotate_pivot(xPivot, yPivot, rotAngle, modelX, modelY)
+  end if
+  !!
   write(outUnit, '(2I8,es18.9e3,i10,i5,2i10,6es18.9e3,i10)')                  &
     timePointIndex, timeStep, pCoord%TrackingTime, sequenceNumber, groupIndex,  &
     particleID, pCoord%CellNumber, pCoord%LocalX, pCoord%LocalY, pCoord%LocalZ, &
     modelX, modelY, pCoord%GlobalZ, pCoord%Layer
-  
+
   end subroutine WriteTimeseriesRecord
+
 
   subroutine WritePathlineHeader(outUnit, trackingDirection, referenceTime,     &
       originX, originY, rotationAngle)
@@ -124,45 +169,69 @@ module ParticleManagerModule
   integer,intent(in) :: outUnit, trackingDirection
   doubleprecision,intent(in) :: referenceTime, originX, originY, rotationAngle
   integer :: version, subversion
-  
+
   version = 7
   subversion = 2
   write(outUnit, '(a,2i10)') 'MODPATH_PATHLINE_FILE', version, subversion
   write(outUnit, '(i5,1x,4e18.10)') trackingDirection, referenceTime, originX, originY, &
       rotationAngle
   write(outUnit, '(a)') 'END HEADER'
-  
+
   end subroutine WritePathlineHeader
-  
-  subroutine WritePathlineRecord(tpResult, outUnit, stressPeriod, timeStep, geoRef)
+
+
+  subroutine WritePathlineRecord(tpResult, outUnit, stressPeriod, timeStep, geoRef, grid)
   use TrackPathResultModule,only : TrackPathResultType
   use ParticleCoordinateModule,only : ParticleCoordinateType
+  use ModflowRectangularGridModule,only : ModflowRectangularGridType
+  use RectangularGridDisvMf6Module,only : RectangularGridDisvMf6Type
   implicit none
+  
   integer,intent(in) :: outUnit, stressPeriod, timeStep
   type(TrackPathResultType),intent(in),target :: tpResult
   type(ParticleCoordinateType),pointer :: c
   type(GeoReferenceType) :: geoRef
   integer :: n, count
   doubleprecision :: modelX, modelY, globalX, globalY
-  
+  doubleprecision :: xPivot, yPivot, rotAngle
+  class(ModflowRectangularGridType),intent(in) :: grid
+
+  select type(grid)
+	class is (RectangularGridDisvMf6Type)
+		xPivot = grid%xPivot
+		yPivot = grid%yPivot
+		rotAngle = grid%rotAngle
+	class default
+		xPivot = 0.0d8
+        yPivot = 0.0d8
+		rotAngle = 0.0d8
+  end select
+
   count = tpResult%ParticlePath%Pathline%GetItemCount()
   if(count .lt. 2) return
-  
+
   write(outUnit, '(4i10)') tpResult%SequenceNumber, tpResult%Group, tpResult%ParticleID, count
   do n = 1, count
         c => tpResult%ParticlePath%Pathline%Items(n)
         modelX = c%GlobalX
         modelY = c%GlobalY
+		!! un-rotate
+		if (rotAngle .ne. 0.0d0) then
+			call rotate_pivot(xPivot, yPivot, rotAngle, modelX, modelY)
+		end if
+		!!
         write(outUnit, "(i10,7es16.7e3,3I10)")                            &
           c%CellNumber, modelX, modelY, c%GlobalZ, c%TrackingTime,        &
           c%LocalX, c%LocalY, c%LocalZ, c%Layer, stressPeriod, timeStep
   end do
- 
+
   end subroutine WritePathlineRecord
-  
-  subroutine WriteBinaryPathlineRecord(tpResult, outUnit, stressPeriod, timeStep, geoRef)
+
+  subroutine WriteBinaryPathlineRecord(tpResult, outUnit, stressPeriod, timeStep, geoRef, grid)
   use TrackPathResultModule,only : TrackPathResultType
   use ParticleCoordinateModule,only : ParticleCoordinateType
+  use ModflowRectangularGridModule,only : ModflowRectangularGridType
+  use RectangularGridDisvMf6Module,only : RectangularGridDisvMf6Type
   implicit none
   integer,intent(in) :: outUnit, stressPeriod, timeStep
   type(TrackPathResultType),intent(in),target :: tpResult
@@ -170,23 +239,41 @@ module ParticleManagerModule
   type(GeoReferenceType) :: geoRef
   integer :: n, count, currentPosition, dataOffset
   doubleprecision :: modelX, modelY, globalX, globalY
-  
+  doubleprecision :: xPivot, yPivot, rotAngle
+  class(ModflowRectangularGridType),intent(in) :: grid
+
+  select type(grid)
+	class is (RectangularGridDisvMf6Type)
+		xPivot = grid%xPivot
+		yPivot = grid%yPivot
+		rotAngle = grid%rotAngle
+	class default
+		xPivot = 0.0d8
+        yPivot = 0.0d8
+		rotAngle = 0.0d8
+  end select
+
   count = tpResult%ParticlePath%Pathline%GetItemCount()
   if(count .lt. 2) return
-  
+
   inquire(unit=outUnit, pos=currentPosition)
   write(outUnit) tpResult%SequenceNumber, count, tpResult%Group, tpResult%ParticleID
   do n = 1, count
         c => tpResult%ParticlePath%Pathline%Items(n)
         modelX = c%GlobalX
         modelY = c%GlobalY
+		! un-rotate
+		if (rotAngle .ne. 0.0d0) then
+			call rotate_pivot(xPivot, yPivot, rotAngle, modelX, modelY)
+		end if
+		!		
         write(outUnit) c%CellNumber, modelX, modelY, c%GlobalZ,           &
           c%TrackingTime, c%LocalX, c%LocalY, c%LocalZ, c%Layer, stressPeriod,  &
           timeStep
   end do
-  
+
   end subroutine WriteBinaryPathlineRecord
-  
+
   subroutine ConsolidatePathlines(inUnit, outUnit, recordCount, particleCount)
   implicit none
   integer, intent(in) :: inUnit, outUnit, recordCount, particleCount
@@ -199,25 +286,25 @@ module ParticleManagerModule
   integer :: cellNumber, layer, pointCount
   doubleprecision :: modelX, modelY, globalZ, trackingTime, localX, localY,   &
     localZ
-  
+
   allocate(sequenceNumbers(recordCount))
   allocate(recordPointCounts(recordCount))
   allocate(recordPointers(recordCount))
   allocate(particlePointCounts(particleCount))
   allocate(particleRecordCounts(particleCount))
-  
+
   ! Initialize all particle point count and record count array elements to 0
   do n = 1, particleCount
       particlePointCounts(n) = 0
       particleRecordCounts(n) = 0
   end do
-  
+
   do n = 1, recordCount
       sequenceNumbers(n) = 0
       recordPointCounts(n) = 0
       recordPointers(n) = 0
-  end do 
-  
+  end do
+
   ! Read and save pathline record header index information
   pos = 1
   do n = 1, recordCount
@@ -231,9 +318,9 @@ module ParticleManagerModule
       dataOffset = 16 + (recordPointCounts(n)*72)
       pos = recordPointers(n) + dataOffset
   end do
-  
-  ! Loop through particles. For each particle, loop through the pathline record headers and read and 
-  ! consolidate pathline points for all of the segments belonging to that particle. Then write the 
+
+  ! Loop through particles. For each particle, loop through the pathline record headers and read and
+  ! consolidate pathline points for all of the segments belonging to that particle. Then write the
   ! consolidated pathline for the particle. Skip particles for which the particlePointCount equals 0.
   do n = 1, particleCount
       if(particlePointCounts(n) .gt. 0) then
@@ -242,7 +329,7 @@ module ParticleManagerModule
               if(sequenceNumbers(m) .eq. n) then
                   ! Increment the record count for this particle
                   count = count + 1
-                  
+
                   ! If this is the first pathline record for this particle, write the record header for the
                   ! consolidated pathline.
                   if(count .eq. 1) then
@@ -255,7 +342,7 @@ module ParticleManagerModule
                       ptr = recordPointers(m) + 16
                       read(inUnit, pos=ptr)
                   end if
-                  
+
                   do i = 1, recordPointCounts(m)
                       read(inUnit) cellNumber, modelX, modelY, globalZ,       &
                         trackingTime, localX, localY, localZ, layer,            &
@@ -266,20 +353,20 @@ module ParticleManagerModule
                         layer, stressPeriod, timeStep
                   end do
               end if
-              ! Check to see if this was the last pathline record for this particle. If so, exit the record loop because there is no need 
+              ! Check to see if this was the last pathline record for this particle. If so, exit the record loop because there is no need
               ! to read through the rest of the records for this particle.
               if(count .eq. particleRecordCounts(n)) exit
           end do
       end if
   end do
-  
+
   end subroutine ConsolidatePathlines
-  
+
   function FindFace(x, y, z) result(face)
   implicit none
   doubleprecision,intent(in) :: x, y, z
   integer :: face
-  
+
   face = 0
   if(x .eq. 0.0d0) then
       face = 1
@@ -294,7 +381,7 @@ module ParticleManagerModule
   else if(z .eq. 1.0d0) then
       face = 6
   end if
-  
+
   end function FindFace
 
 end module ParticleManagerModule

--- a/source/UtilMisc.f90
+++ b/source/UtilMisc.f90
@@ -206,4 +206,27 @@ end subroutine ulog
       END DO
    END SUBROUTINE  Sort
 
+! --------------------------------------------------------------------
+! SUBROUTINE  rotate_pivot():
+!    This subroutine takes point coordinates and modifies them according to (x,y)Pivot
+! and rotAngle (in radians).
+! --------------------------------------------------------------------
+
+  subroutine rotate_pivot(xPivot, yPivot, rotAngle, modelX, modelY)
+  doubleprecision,intent(in) :: xPivot, yPivot, rotAngle
+  doubleprecision,intent(inout) :: modelX, modelY
+  doubleprecision :: tmpX, tmpY
+  
+  tmpX = modelX*cos(rotAngle) - modelY*sin(rotAngle)
+  tmpY = modelX*sin(rotAngle) + modelY*cos(rotAngle)
+  
+  modelX = tmpX + xPivot
+  modelY = tmpY + yPivot
+
+  end subroutine rotate_pivot
+
+
+
+
+
 end module UtilMiscModule


### PR DESCRIPTION
Intended behaviour: when a grid does not meet requirements (smoothed & rectangular):
1/ rotate the DISV grid, 
2/ track particles on the rotated grid (no modifications), 
3/ un-rotate the results (pathlines/endpoints/timeseries).
I did not use the (OriginX, OriginY, RotationAngle)  features in the output files' headers because it might raise other issues.
Comments & improvements are welcome!