### PR TITLE
update build config and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: modpath-v7 compiler checks
+name: modpath-v7 checks
 on:
   # run at 6 AM UTC every day
   schedule:
@@ -25,18 +25,18 @@ jobs:
       matrix:
         include:
           # test latest gcc
-          - {os: ubuntu-latest, compiler: gcc, version: 13, shell: bash, release: no, xcode: none}
-          - {os: macos-14, compiler: gcc, version: 13, shell: bash, release: yes, xcode: 14.3.1}
-          - {os: windows-latest, compiler: gcc, version: 13, shell: pwsh, release: no, xcode: none}
+          - {os: ubuntu-latest, compiler: gcc, version: 13, shell: bash, release: no}
+          - {os: macos-14, compiler: gcc, version: 13, shell: bash, release: yes}
+          - {os: macos-15-intel, compiler: gcc, version: 13, shell: bash, release: yes}
+          - {os: windows-latest, compiler: gcc, version: 13, shell: pwsh, release: no}
           # test intel-classic
-          - {os: ubuntu-22.04, compiler: intel-classic, version: 2021.7, shell: bash, release: no, xcode: none}
-          - {os: macos-15-intel, compiler: intel-classic, version: 2021.6, shell: bash, release: yes, xcode: 16.4}
+          - {os: ubuntu-22.04, compiler: intel-classic, version: 2021.7, shell: bash, release: no}
           # test previous gcc
-          - {os: ubuntu-latest, compiler: gcc, version: 12, shell: bash, release: no, xcode: none}
-          - {os: ubuntu-latest, compiler: gcc, version: 11, shell: bash, release: no, xcode: none}
+          - {os: ubuntu-latest, compiler: gcc, version: 12, shell: bash, release: no}
+          - {os: ubuntu-latest, compiler: gcc, version: 11, shell: bash, release: no}
           # test ifx
-          - {os: ubuntu-22.04, compiler: intel, version: "2025.0", shell: bash, release: yes, xcode: none}
-          - {os: windows-2022, compiler: intel, version: "2025.0", shell: pwsh, release: yes, xcode: none}
+          - {os: ubuntu-22.04, compiler: intel, version: "2025.0", shell: bash, release: yes}
+          - {os: windows-2022, compiler: intel, version: "2025.0", shell: pwsh, release: yes}
     defaults:
       run:
         shell: ${{ matrix.shell }}
@@ -45,11 +45,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: ${{ env.PROGRAM_NAME }}
-
-      - uses: maxim-lobanov/setup-xcode@v1
-        if: ${{ (runner.os == 'macOS') && (matrix.compiler == 'intel-classic') }}
-        with:
-          xcode-version: ${{ matrix.xcode }}
 
       - name: Setup ${{ matrix.compiler }} ${{ matrix.version }} on ${{ matrix.os }}
         uses: fortran-lang/setup-fortran@v1
@@ -70,6 +65,26 @@ jobs:
         run: |
           echo "ostag=$(pixi run get-ostag)" >> $GITHUB_ENV
 
+      # static link gfortran libs
+      - name: Hide dylibs (macOS)
+        if: runner.os == 'macOS'
+        working-directory: ${{ env.PROGRAM_NAME }}
+        run: |
+          version="${{ matrix.version }}"
+          brew_prefix="$(brew --prefix)"
+          libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgcc_s.1.1.dylib $libpath/libgcc_s.1.1.dylib.bak
+          mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
+          mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak
+          mv $libpath/libstdc++.6.dylib $libpath/libstdc++.6.dylib.bak
+
+      # static link libgcc
+      - name: Set LDFLAGS (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          ldflags="$LDFLAGS -static-libgcc"
+          echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
+
       - name: Create source zip file on Linux
         if: ${{ matrix.release == 'yes' && runner.os == 'Linux' }}
         working-directory: ${{ env.PROGRAM_NAME }}
@@ -83,6 +98,13 @@ jobs:
           pixi run setup
           pixi run build
 
+      - name: Check architecture (macOS)
+        working-directory: ${{ env.PROGRAM_NAME }}/bin
+        if: runner.os == 'macOS'
+        run: |
+          otool -L mp7
+          lipo -info mp7
+
       - name: Show build log
         if: failure()
         working-directory: ${{ env.PROGRAM_NAME }}
@@ -92,7 +114,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: meson-log.txt
+          name: ${{ matrix.os }}-${{ matrix.compiler}}-${{ matrix.version }}-meson-log.txt
           path: ${{ env.PROGRAM_NAME }}/builddir/meson-logs/meson-log.txt
 
       - name: Unit test ${{ env.PROGRAM_NAME }}
@@ -136,7 +158,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: ${{ env.PROGRAM_NAME }}
-
 
       - name: Extract version number from the main meson.build file
         working-directory: ${{ env.PROGRAM_NAME }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # modpath-v7
-MODPATH version 7 -- Particle tracking for MODFLOW-2005, MODFLOW-USG, and MODFLOW-6
+MODPATH 7: Particle tracking for MODFLOW-2005, MODFLOW-USG, and MODFLOW-6
+
+[![mp7 checks](https://github.com/MODFLOW-ORG/modpath-v7/actions/workflows/ci.yml/badge.svg)](https://github.com/MODFLOW-ORG/modpath-v7/actions/workflows/ci.yml)

--- a/meson.build
+++ b/meson.build
@@ -15,10 +15,16 @@ message('Compiler ID:', fc_id)
 
 compile_args = []
 link_args = []
+extra_deps = []
 
 if fc_id == 'gcc'
   # GCC/gfortran specific flags
   compile_args += ['-cpp', '-ffree-line-length-none']
+  # Link quadmath library on macOS (required for gfortran runtime)
+  if host_machine.system() == 'darwin'
+    quadmath_dep = fc.find_library('quadmath', required: true, static: true)
+    extra_deps += [quadmath_dep]
+  endif
 elif fc_id == 'intel'
   # Intel ifx specific flags
   compile_args += ['-fpp', '-diag-disable=10441']

--- a/source/meson.build
+++ b/source/meson.build
@@ -53,6 +53,7 @@ sources = [
 exe = executable(
                  'mp7',
                  sources,
+                 dependencies: extra_deps,
                  link_language : 'fortran',
                  install: true
                 )


### PR DESCRIPTION
* switch `macos-15-intel` build from intel classic to gcc/gfortran
* hide dylibs, use `-static-libgcc`, and add explicit libquadmath dependency in `meson.build` for static(ish) gfortran build on mac
* set link language to fortran in `meson.build` (defensive)
* unique name for uploaded build logs on failure
* add CI badge to README